### PR TITLE
Add PR body in the metadata provided by 'get' steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ is available as `.git/resource/base_sha`. For a complete list of available (indi
 - `author_email`: the e-mail address of the pull request author
 - `base_name`: the base branch of the pull request
 - `base_sha`: the commit of the base branch of the pull request
+- `body`: the description of the pull request
 - `head_name`: the branch associated with the pull request
 - `head_sha`: the latest commit hash of the branch associated with the pull request
 - `message`: the message of the last commit of the pull request, as designated by `head_sha`
@@ -291,13 +292,16 @@ If you are coming from [jtarchie/github-pullrequest-resource][original-resource]
 #### Metadata stored in the `.git` directory
 
 The original resource stores [a bunch of metadata][metadata] related to the
-pull request as `git config`, or plain files in the `.git` directory. This
-resource provide most metadata with possibly different names, and the files
-are to be found in the `.git/reource` directory.
+pull request as entries in `.git/config`, or plain files in the `.git/`
+directory.
 
-If you were using the metadata stored in Git config, you need to update your
-code. For example `git config --get pullrequest.url` in some Bash code can be
-replaced by `echo $(< .git/resource/url)`.
+This resource provide all these metadata, but with possibly different names,
+and only as files to be found in the `.git/resource` directory.
+
+With this resource, no entry is added to the `.git/config` file. If you were
+using the metadata stored in Git config, you need to update your code. For
+example `git config --get pullrequest.url` in some Bash code can be replaced
+by `echo $(< .git/resource/url)`.
 
 Here is the list of changes:
 
@@ -308,7 +312,7 @@ Here is the list of changes:
 - `.git/branch` -> `.git/resource/head_name`
 - `.git/head_sha` -> `.git/resource/head_sha`
 - `.git/userlogin` -> `.git/resource/author`
-- `.git/body` -> _no equivalent_
+- `.git/body` -> `.git/resource/body`
 
 [metadata]: https://github.com/jtarchie/github-pullrequest-resource#in-clone-the-repository-at-the-given-pull-request-ref
 

--- a/in.go
+++ b/in.go
@@ -43,6 +43,7 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 	var metadata Metadata
 	metadata.Add("pr", strconv.Itoa(pull.Number))
 	metadata.Add("title", pull.Title)
+	metadata.Add("body", pull.Body)
 	metadata.Add("url", pull.URL)
 	metadata.Add("head_name", pull.HeadRefName)
 	metadata.Add("head_sha", pull.Tip.OID)

--- a/in_test.go
+++ b/in_test.go
@@ -43,8 +43,8 @@ func TestGet(t *testing.T) {
 			parameters:        resource.GetParameters{},
 			pullRequest:       createTestPR(1, "master", "anonymous", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
 			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","state":"OPEN"}`,
-			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
-			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"body","value":"pr1 body"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","body":"pr1 body","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports unlocking with git crypt",
@@ -62,8 +62,8 @@ func TestGet(t *testing.T) {
 			parameters:        resource.GetParameters{},
 			pullRequest:       createTestPR(1, "master", "anonymous", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
 			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","state":"OPEN"}`,
-			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
-			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"body","value":"pr1 body"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","body":"pr1 body","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports rebasing",
@@ -82,8 +82,8 @@ func TestGet(t *testing.T) {
 			},
 			pullRequest:       createTestPR(1, "master", "anonymous", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
 			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","state":"OPEN"}`,
-			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
-			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"body","value":"pr1 body"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","body":"pr1 body","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports checkout",
@@ -102,8 +102,8 @@ func TestGet(t *testing.T) {
 			},
 			pullRequest:       createTestPR(1, "master", "anonymous", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
 			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","state":"OPEN"}`,
-			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
-			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"body","value":"pr1 body"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","body":"pr1 body","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports git_depth",
@@ -122,8 +122,8 @@ func TestGet(t *testing.T) {
 			},
 			pullRequest:       createTestPR(1, "master", "anonymous", false, false, 0, nil, false, githubv4.PullRequestStateOpen),
 			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","state":"OPEN"}`,
-			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
-			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"body","value":"pr1 body"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","body":"pr1 body","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 		},
 		{
 			description: "get supports list_changed_files",
@@ -150,8 +150,8 @@ func TestGet(t *testing.T) {
 				},
 			},
 			versionString:     `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","state":"OPEN"}`,
-			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
-			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
+			metadataString:    `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"body","value":"pr1 body"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
+			metadataMapString: `{"author":"login1","author_email":"user@example.com","base_name":"master","base_sha":"sha","body":"pr1 body","head_name":"pr1","head_sha":"oid1","message":"commit message1","pr":"1","state":"OPEN","title":"pr1 title","url":"pr1 url"}`,
 			filesString:       "README.md\nOther.md\n",
 		},
 	}
@@ -200,6 +200,7 @@ func TestGet(t *testing.T) {
 					"author":       "login1",
 					"author_email": "user@example.com",
 					"title":        "pr1 title",
+					"body":         "pr1 body",
 				}
 
 				for filename, expected := range files {
@@ -353,6 +354,7 @@ func createTestPR(
 			ID:          fmt.Sprintf("pr%s", n),
 			Number:      count,
 			Title:       fmt.Sprintf("pr%s title", n),
+			Body:        fmt.Sprintf("pr%s body", n),
 			URL:         fmt.Sprintf("pr%s url", n),
 			BaseRefName: baseName,
 			HeadRefName: fmt.Sprintf("pr%s", n),

--- a/models.go
+++ b/models.go
@@ -103,6 +103,7 @@ type PullRequestObject struct {
 	ID          string
 	Number      int
 	Title       string
+	Body        string
 	URL         string
 	BaseRefName string
 	HeadRefName string


### PR DESCRIPTION
This is the telia-oss/github-pr-resource#277 PR that I've ported here in this fork.

Here is an implementation that fixes issue telia-oss/github-pr-resource#194, providing the description body as metadata.

The documentation has been updated, and test are running fine.